### PR TITLE
fix(style): Fix the style of the checkbox disabled style.

### DIFF
--- a/checkbox.scss
+++ b/checkbox.scss
@@ -107,8 +107,8 @@ $checkbox-active-color: unquote("rgba(#{$color-active}, 1.0)") !default;
 
   fieldset[disabled] .fxa-checkbox &,
   .fxa-checkbox.is-disabled & {
-    border: 2px solid $checkbox-disabled-color;
     cursor: auto;
+    filter: opacity(30%);
   }
 }
 
@@ -145,10 +145,6 @@ $checkbox-active-color: unquote("rgba(#{$color-active}, 1.0)") !default;
     background-size: cover;
   }
 
-  fieldset[disabled] .fxa-checkbox.is-checked &,
-  .fxa-checkbox.is-checked.is-disabled & {
-    background: $checkbox-disabled-color url($tick);
-  }
 }
 
 .fxa-checkbox__label {
@@ -160,7 +156,6 @@ $checkbox-active-color: unquote("rgba(#{$color-active}, 1.0)") !default;
 
   fieldset[disabled] .fxa-checkbox &,
   .fxa-checkbox.is-disabled & {
-    color: $checkbox-disabled-color;
     cursor: auto;
   }
 }


### PR DESCRIPTION
Apply a 60% opacity filter instead of a background color.

@ryanfeeley, @vladikoff - r? Here's the new checkbox disabled style:

![screen shot 2016-02-19 at 13 11 10](https://cloud.githubusercontent.com/assets/848085/13176459/59a3a062-d70a-11e5-9b25-0dc95d9f2c76.png)
