### PR TITLE
fix(style): Only show tick mark on down state, if checkbox is checked

### DIFF
--- a/checkbox.scss
+++ b/checkbox.scss
@@ -58,10 +58,12 @@ $checkbox-active-color: unquote("rgba(#{$color-active}, 1.0)") !default;
         border: 2px solid $checkbox-active-color;
       }
 
-      .fxa-checkbox__tick-outline {
-        background: url($tick);
-        background-size: cover;
-        filter: saturate(30%) brightness(50%);
+      &.is-checked {
+        .fxa-checkbox__tick-outline {
+          background: url($tick);
+          background-size: cover;
+          filter: saturate(40%) brightness(50%);
+        }
       }
     }
   }


### PR DESCRIPTION
This PR fixes inconsistency with the styling of the checkbox.
- Fixes downstate on unchecked box to better match https://github.com/mozilla/fxa-content-server/issues/3394
- Update saturation to 40% https://github.com/mozilla/fxa-content-server/issues/3394#issuecomment-179934190

@vladikoff r?
