### PR TITLE
style(checkbox-height): fix height of checkbox

### DIFF
--- a/checkbox.scss
+++ b/checkbox.scss
@@ -43,6 +43,7 @@ $checkbox-active-color: unquote("rgba(#{$color-active}, 1.0)") !default;
   box-sizing: border-box;
   cursor: pointer;
   height: $checkbox-label-height;
+  line-height: $checkbox-label-height;
   margin: 0;
   padding: 0;
   position: relative;


### PR DESCRIPTION
Fixes #3 
Instead of having `.fxa-checkbox` display set to block (which doesnt guarantee the height if the developer including fxa-checkbox has it set to inline, and makes the clickable area larger like in the fxa-content-server), setting line-height on it will force its closest `block`ed parent to expand to accomodate the line-height.
@shane-tomlinson 
@vbudhram 
